### PR TITLE
Correct month number

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ class Logger {
 
         // Date- and time-related variables
         const date = new Date();
-        const fileName = `${("0" + date.getUTCFullYear()).slice(-2)}-${("0" + date.getUTCMonth()).slice(-2)}-${("0" + date.getUTCDate()).slice(-2)}`;
+        const fileName = `${("0" + date.getUTCFullYear()).slice(-2)}-${("0" + (date.getUTCMonth() + 1)).slice(-2)}-${("0" + date.getUTCDate()).slice(-2)}`;
         const timestamp = `${("0" + date.getUTCHours()).slice(-2)}:${("0" + date.getUTCMinutes()).slice(-2)}:${("0" + date.getUTCSeconds()).slice(-2)}`;
 
         fs.appendFileSync(`${this.logsPath}${fileName}.log`, `[${timestamp}] [${type.toUpperCase()}]: ${message}\n`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@moaufmklo/logger",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Dependency-free Node.js module for simple, rotating, file-based logging",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
This resolves #1. With log files now being named correctly, it is important to rename files before 1.0.1 for consistency.